### PR TITLE
Add new API methods

### DIFF
--- a/specification/metaplex-das-api.json
+++ b/specification/metaplex-das-api.json
@@ -1,7 +1,7 @@
 {
   "openrpc": "1.2.1",
   "info": {
-    "version": "1.0.0",
+    "version": "1.1.0",
     "title": "Metaplex Digital Asset Standard API"
   },
   "methods": [
@@ -19,7 +19,35 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/asset"
+        "name": "Asset",
+        "description": "The asset metadata",
+        "schema": {
+          "$ref": "#/components/schemas/Asset"
+        }
+      }
+    },
+    {
+      "name": "getAssets",
+      "description": "Return the metadata information of a compressed/standard assets",
+      "params": [
+        {
+          "name": "ids",
+          "description": "The ids of the assets",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     },
     {
@@ -36,7 +64,118 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetProof"
+        "name": "AssetProof",
+        "description": "The merkle tree proof information for the asset",
+        "schema": {
+          "$ref": "#/components/schemas/AssetProof"
+        }
+      }
+    },
+    {
+      "name": "getAssetProofs",
+      "description": "Return the merkle tree proof information for compressed assets",
+      "params": [
+        {
+          "name": "ids",
+          "description": "The ids of the assets",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "AssetProofs",
+        "description": "List of AssetProof for the IDs requested",
+        "schema": {
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/AssetProof"
+          }
+        }
+      }
+    },
+    {
+      "name": "getAssetSignatures",
+      "description": "Return the tansaction signatures for a compressed asset",
+      "params": [
+        {
+          "name": "id",
+          "description": "The id of the asset",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "description": "The maximum number of signatures to retrieve",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "page",
+          "description": "The index of the \"page\" to retrieve",
+          "schema": {
+            "type": "number"
+          }
+        },
+        {
+          "name": "before",
+          "description": "Retrieve signature before the specified signature",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "after",
+          "description": "Retrieve signatures after the specified signature",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "treeId",
+          "description": "The merkle tree id of the asset",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "leafIndex",
+          "description": "The leaf index of the asset",
+          "required": false,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "Signatures",
+        "description": "List of signatures for the asset",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "total": {
+              "type": "number"
+            },
+            "limit": {
+              "type": "number"
+            },
+            "page": {
+              "type": "number"
+            },
+            "signatures": {
+              "type": "array",
+              "$ref": "#/components/schemas/AssetSignature"
+            }
+          }
+        }
       }
     },
     {
@@ -56,7 +195,7 @@
           "description": "Sorting criteria",
           "schema": {
             "type": "object",
-            "$ref": "#/components/contentDescriptors/sortBy"
+            "$ref": "#/components/schemas/SortBy"
           }
         },
         {
@@ -89,7 +228,11 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetList"
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     },
     {
@@ -116,7 +259,7 @@
           "description": "Sorting criteria",
           "schema": {
             "type": "object",
-            "$ref": "#/components/contentDescriptors/sortBy"
+            "$ref": "#/components/schemas/SortBy"
           }
         },
         {
@@ -149,7 +292,11 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetList"
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     },
     {
@@ -177,7 +324,7 @@
           "description": "Sorting criteria",
           "schema": {
             "type": "object",
-            "$ref": "#/components/contentDescriptors/sortBy"
+            "$ref": "#/components/schemas/SortBy"
           }
         },
         {
@@ -210,7 +357,11 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetList"
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     },
     {
@@ -230,7 +381,7 @@
           "description": "Sorting criteria",
           "schema": {
             "type": "object",
-            "$ref": "#/components/contentDescriptors/sortBy"
+            "$ref": "#/components/schemas/SortBy"
           }
         },
         {
@@ -263,7 +414,11 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetList"
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     },
     {
@@ -439,7 +594,7 @@
           "description": "Sorting criteria",
           "schema": {
             "type": "object",
-            "$ref": "#/components/contentDescriptors/sortBy"
+            "$ref": "#/components/schemas/SortBy"
           }
         },
         {
@@ -479,385 +634,388 @@
         }
       ],
       "result": {
-        "$ref": "#/components/contentDescriptors/assetList"
+        "name": "AssetList",
+        "description": "The list of assets",
+        "schema": {
+          "$ref": "#/components/schemas/AssetList"
+        }
       }
     }
   ],
   "components": {
-    "contentDescriptors": {
-      "asset": {
-        "name": "Asset",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "interface": {
-              "type": "string",
-              "enum": [
-                "V1_NFT",
-                "V1_PRINT",
-                "LEGACY_NFT",
-                "V2_NFT",
-                "FungibleAsset",
-                "Custom",
-                "Identity",
-                "Executable",
-                "ProgrammableNFT"
-              ]
-            },
-            "id": {
-              "type": "string"
-            },
-            "content": {
-              "type": "object",
-              "required": [
-                "$schema"
-              ],
-              "properties": {
-                "$schema": {
-                  "type": "string"
-                },
-                "json_uri": {
-                  "type": "string"
-                },
-                "files": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "uri",
-                      "mime"
-                    ],
-                    "properties": {
-                      "uri": {
-                        "type": "string"
-                      },
-                      "mime": {
-                        "type": "string"
-                      },
-                      "quality": {
-                        "type": "object",
-                        "properties": {
-                          "$$schema": {
-                            "type": "string"
-                          }
-                        }
-                      },
-                      "contexts": {
-                        "type": "array",
-                        "items": {
-                          "type": "string",
-                          "enum": [
-                            "wallet-default",
-                            "web-desktop",
-                            "web-mobile",
-                            "app-mobile",
-                            "app-desktop",
-                            "app",
-                            "vr"
-                          ]
-                        }
-                      }
-                    }
-                  }
-                },
-                "metadata": {
+    "schemas": {
+      "Asset": {
+        "type": "object",
+        "properties": {
+          "interface": {
+            "type": "string",
+            "enum": [
+              "V1_NFT",
+              "V1_PRINT",
+              "LEGACY_NFT",
+              "V2_NFT",
+              "FungibleAsset",
+              "Custom",
+              "Identity",
+              "Executable",
+              "ProgrammableNFT"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "content": {
+            "type": "object",
+            "required": [
+              "$schema"
+            ],
+            "properties": {
+              "$schema": {
+                "type": "string"
+              },
+              "json_uri": {
+                "type": "string"
+              },
+              "files": {
+                "type": "array",
+                "items": {
                   "type": "object",
                   "required": [
-                    "name",
-                    "symbol"
+                    "uri",
+                    "mime"
                   ],
                   "properties": {
-                    "name": {
+                    "uri": {
                       "type": "string"
                     },
-                    "description": {
+                    "mime": {
                       "type": "string"
                     },
-                    "symbol": {
-                      "type": "string"
+                    "quality": {
+                      "type": "object",
+                      "properties": {
+                        "$$schema": {
+                          "type": "string"
+                        }
+                      }
                     },
-                    "token_standard": {
-                      "type": "string",
-                      "enum": [
-                        "NonFungible",
-                        "FungibleAsset",
-                        "Fungible",
-                        "NonFungibleEdition",
-                        "ProgrammableNonFungible",
-                        "ProgrammableNonFungibleEdition"
-                      ]
-                    },
-                    "attributes": {
+                    "contexts": {
                       "type": "array",
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "value": {
-                            "type": "string"
-                          },
-                          "trait_type": {
-                            "type": "string"
-                          }
+                        "type": "string",
+                        "enum": [
+                          "wallet-default",
+                          "web-desktop",
+                          "web-mobile",
+                          "app-mobile",
+                          "app-desktop",
+                          "app",
+                          "vr"
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "metadata": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "symbol"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "symbol": {
+                    "type": "string"
+                  },
+                  "token_standard": {
+                    "type": "string",
+                    "enum": [
+                      "NonFungible",
+                      "FungibleAsset",
+                      "Fungible",
+                      "NonFungibleEdition",
+                      "ProgrammableNonFungible",
+                      "ProgrammableNonFungibleEdition"
+                    ]
+                  },
+                  "attributes": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "value": {
+                          "type": "string"
+                        },
+                        "trait_type": {
+                          "type": "string"
                         }
                       }
                     }
                   }
-                },
-                "links": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
                 }
-              }
-            },
-            "authorities": {
-              "type": "array",
-              "items": {
+              },
+              "links": {
                 "type": "object",
-                "properties": {
-                  "address": {
-                    "type": "string"
-                  },
-                  "scopes": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "enum": [
-                        "full",
-                        "royalty",
-                        "metadata",
-                        "extension"
-                      ]
-                    }
-                  }
-                }
-              }
-            },
-            "compression": {
-              "type": "object",
-              "properties": {
-                "eligible": {
-                  "type": "boolean"
-                },
-                "compressed": {
-                  "type": "boolean"
-                },
-                "data_hash": {
-                  "type": "string"
-                },
-                "creator_hash": {
-                  "type": "string"
-                },
-                "asset_hash": {
-                  "type": "string"
-                },
-                "tree": {
-                  "type": "string"
-                },
-                "seq": {
-                  "type": "number"
-                },
-                "leaf_id": {
+                "additionalProperties": {
                   "type": "string"
                 }
               }
-            },
-            "grouping": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "group_key": {
-                    "type": "string"
-                  },
-                  "group_value": {
-                    "type": "string"
-                  }
-                }
-              }
-            },
-            "royalty": {
-              "type": "object",
-              "properties": {
-                "royalty_model": {
-                  "type": "string",
-                  "enum": [
-                    "creators",
-                    "fanout",
-                    "single"
-                  ]
-                },
-                "target": {
-                  "type": "string"
-                },
-                "percent": {
-                  "type": "number"
-                },
-                "basis_points": {
-                  "type": "number"
-                },
-                "primary_sale_happened": {
-                  "type": "boolean"
-                },
-                "locked": {
-                  "type": "boolean"
-                }
-              }
-            },
-            "creators": {
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "address": {
-                    "type": "string"
-                  },
-                  "share": {
-                    "type": "number"
-                  },
-                  "verified": {
-                    "type": "boolean"
-                  }
-                }
-              }
-            },
-            "ownership": {
-              "type": "object",
-              "properties": {
-                "frozen": {
-                  "type": "boolean"
-                },
-                "delegated": {
-                  "type": "boolean"
-                },
-                "delegate": {
-                  "type": "string"
-                },
-                "ownership_model": {
-                  "type": "string",
-                  "enum": [
-                    "single",
-                    "token"
-                  ]
-                },
-                "owner": {
-                  "type": "string"
-                }
-              }
-            },
-            "uses": {
-              "type": "object",
-              "properties": {
-                "use_method": {
-                  "type": "string",
-                  "enum": [
-                    "burn",
-                    "multiple",
-                    "single"
-                  ]
-                },
-                "remaining": {
-                  "type": "number"
-                },
-                "total": {
-                  "type": "number"
-                }
-              }
-            },
-            "supply": {
-              "type": "object",
-              "properties": {
-                "print_max_supply": {
-                  "type": "number"
-                },
-                "print_current_supply": {
-                  "type": "number"
-                },
-                "edition_nonce": {
-                  "type": "number"
-                }
-              }
-            },
-            "mutable": {
-              "type": "boolean"
-            },
-            "burnt": {
-              "type": "boolean"
             }
-          }
-        }
-      },
-      "assetList": {
-        "name": "AssetList",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "total": {
-              "type": "number"
-            },
-            "limit": {
-              "type": "number"
-            },
+          },
+          "authorities": {
+            "type": "array",
             "items": {
-              "type": "array",
-              "$ref": "#/components/contentDescriptors/asset"
+              "type": "object",
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "full",
+                      "royalty",
+                      "metadata",
+                      "extension"
+                    ]
+                  }
+                }
+              }
             }
-          }
-        }
-      },
-      "assetProof": {
-        "name": "AssetProof",
-        "schema": {
-          "type": "object",
-          "required": [
-            "node_index",
-            "tree_id",
-            "proof"
-          ],
-          "properties": {
-            "root": {
-              "type": "string"
-            },
-            "proof": {
-              "type": "array",
-              "items": {
+          },
+          "compression": {
+            "type": "object",
+            "properties": {
+              "eligible": {
+                "type": "boolean"
+              },
+              "compressed": {
+                "type": "boolean"
+              },
+              "data_hash": {
+                "type": "string"
+              },
+              "creator_hash": {
+                "type": "string"
+              },
+              "asset_hash": {
+                "type": "string"
+              },
+              "tree": {
+                "type": "string"
+              },
+              "seq": {
+                "type": "number"
+              },
+              "leaf_id": {
                 "type": "string"
               }
-            },
-            "node_index": {
-              "type": "number"
-            },
-            "leaf": {
-              "type": "string"
-            },
-            "tree_id": {
-              "type": "string"
             }
+          },
+          "grouping": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "group_key": {
+                  "type": "string"
+                },
+                "group_value": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "royalty": {
+            "type": "object",
+            "properties": {
+              "royalty_model": {
+                "type": "string",
+                "enum": [
+                  "creators",
+                  "fanout",
+                  "single"
+                ]
+              },
+              "target": {
+                "type": "string"
+              },
+              "percent": {
+                "type": "number"
+              },
+              "basis_points": {
+                "type": "number"
+              },
+              "primary_sale_happened": {
+                "type": "boolean"
+              },
+              "locked": {
+                "type": "boolean"
+              }
+            }
+          },
+          "creators": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "share": {
+                  "type": "number"
+                },
+                "verified": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "ownership": {
+            "type": "object",
+            "properties": {
+              "frozen": {
+                "type": "boolean"
+              },
+              "delegated": {
+                "type": "boolean"
+              },
+              "delegate": {
+                "type": "string"
+              },
+              "ownership_model": {
+                "type": "string",
+                "enum": [
+                  "single",
+                  "token"
+                ]
+              },
+              "owner": {
+                "type": "string"
+              }
+            }
+          },
+          "uses": {
+            "type": "object",
+            "properties": {
+              "use_method": {
+                "type": "string",
+                "enum": [
+                  "burn",
+                  "multiple",
+                  "single"
+                ]
+              },
+              "remaining": {
+                "type": "number"
+              },
+              "total": {
+                "type": "number"
+              }
+            }
+          },
+          "supply": {
+            "type": "object",
+            "properties": {
+              "print_max_supply": {
+                "type": "number"
+              },
+              "print_current_supply": {
+                "type": "number"
+              },
+              "edition_nonce": {
+                "type": "number"
+              }
+            }
+          },
+          "mutable": {
+            "type": "boolean"
+          },
+          "burnt": {
+            "type": "boolean"
           }
         }
       },
-      "sortBy": {
-        "name": "sortBy",
-        "schema": {
-          "type": "object",
-          "properties": {
-            "sortBy": {
-              "type": "string",
-              "enum": [
-                "created",
-                "updated",
-                "recent_action",
-                "none"
-              ]
-            },
-            "sortDirection": {
-              "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+      "AssetList": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number"
+          },
+          "limit": {
+            "type": "number"
+          },
+          "items": {
+            "type": "array",
+            "$ref": "#/components/schemas/Asset"
+          }
+        }
+      },
+      "AssetProof": {
+        "type": "object",
+        "required": [
+          "node_index",
+          "tree_id",
+          "proof"
+        ],
+        "properties": {
+          "root": {
+            "type": "string"
+          },
+          "proof": {
+            "type": "array",
+            "items": {
+              "type": "string"
             }
+          },
+          "node_index": {
+            "type": "number"
+          },
+          "leaf": {
+            "type": "string"
+          },
+          "tree_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AssetSignature": {
+        "type": "object",
+        "properties": {
+          "signature": {
+            "type": "string"
+          },
+          "instruction": {
+            "type": "string"
+          }
+        }
+      },
+      "SortBy": {
+        "type": "object",
+        "properties": {
+          "sortBy": {
+            "type": "string",
+            "enum": [
+              "created",
+              "updated",
+              "recent_action",
+              "none"
+            ]
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ]
           }
         }
       }


### PR DESCRIPTION
This PR adds 3 new methods to the DAS API specification:
- `getAssets`
- `getAssetProofs`
- `getAssetSignatures`

![image](https://github.com/metaplex-foundation/digital-asset-standard-api/assets/729235/c8a16991-6609-4883-9715-01037663fba2)
