### PR TITLE
feat(module augmentations): augment umi module directly

### DIFF
--- a/clients/js/src/plugin.ts
+++ b/clients/js/src/plugin.ts
@@ -7,7 +7,7 @@ export const dasApi = (): UmiPlugin => ({
   },
 });
 
-declare module '@metaplex-foundation/umi' {
+declare module '@metaplex-foundation/umi/dist/types/Umi' {
   interface Umi {
     rpc: RpcInterface & DasApiInterface;
   }


### PR DESCRIPTION
# Description

The `Umi` interface is augmented directly in its module file.

Supposably it should fix problems with nested module augmentations. The problem appears when this DAS client is a peer dependency of some other package/client which also tries to augment the same thing, the `Umi` interface in this case. This leads to module override rather than augmentation and the `Umi` interface loses its original properties such as `payer`, `identity`, `programs` etc.

P.S. It should be published as an alpha version (or use any other approach) to prevent people from updating right away and have some time to test it.