### PR TITLE
Update version

### DIFF
--- a/clients/js/package.json
+++ b/clients/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@metaplex-foundation/digital-asset-standard-api",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Open-source specification for interacting with digital assets on Solana",
     "main": "dist/src/index.js",
     "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Already deployed on npm through CI
https://www.npmjs.com/package/@metaplex-foundation/digital-asset-standard-api

Additional features, so this is technically not following semver since i used the GH action incorrectly. Should have been 1.1 probably. It's fully backwards compatible though. 
Would use 1.1 when the additional displayOptions etc. are added in the follow up PR,