### PR TITLE
Add support for Bubblegum leaf schema V2

### DIFF
--- a/clients/js/src/types.ts
+++ b/clients/js/src/types.ts
@@ -460,6 +460,9 @@ export type DasApiAssetCompression = {
   compressed: boolean;
   data_hash: PublicKey;
   creator_hash: PublicKey;
+  collection_hash?: PublicKey;
+  asset_data_hash?: PublicKey;
+  flags?: number;
   asset_hash: PublicKey;
   tree: PublicKey;
   seq: number;
@@ -468,6 +471,7 @@ export type DasApiAssetCompression = {
 
 export type DasApiAssetOwnership = {
   frozen: boolean;
+  non_transferable?: boolean;
   delegated: boolean;
   delegate: PublicKey | null;
   ownership_model: 'single' | 'token';


### PR DESCRIPTION
### Notes
* Added fields that are in Bubblegum leaf schema V2 as optional fields.

### Testing
* Did not add CI tests as we don't have real V2 yet and its also only being indexed by one RPC on devnet.
* Tested that a V1 asset works still (no regression)
* Tested that a V2 asset works

#### V1 asset
```
{
  interface: 'V1_NFT',
  id: 'AJKBo9b7ouxXWmSxWzByJyKqZMV7pRkYQTkMtA6hZkaV',
  content: {
    '$schema': 'https://schema.metaplex.com/nft1.0.json',
    json_uri: 'https://example.com/my-nft.json',
    files: [],
    metadata: { name: 'My NFT', symbol: '', token_standard: 'NonFungible' },
    links: {}
  },
  authorities: [
    {
      address: '5X4iSUgEfaNBRn5HQfM24Ck5mFaTyKCUpuegytig33qR',
      scopes: [Array]
    }
  ],
  compression: {
    eligible: false,
    compressed: true,
    data_hash: 'HB6sKWxroCdwkChjxckW3CF3fWupZHhPEua62GF46Ljs',
    creator_hash: 'EKDHSGbrGztomDfuiV4iqiZ6LschDJPsFiXjZ83f92Md',
    asset_hash: 'CEzzR2XKcggEP9r24cJ6hXBm116cmmJQYA79iiy1MQVZ',
    tree: '33v2L6S9X1eZ7kHYLkwjHA6ZbTd7GJfYvUTLwDrvN8W2',
    seq: 1,
    leaf_id: 0
  },
  grouping: [],
  royalty: {
    royalty_model: 'creators',
    target: null,
    percent: 0.05,
    basis_points: 500,
    primary_sale_happened: false,
    locked: false
  },
  creators: [],
  ownership: {
    frozen: false,
    delegated: false,
    delegate: null,
    ownership_model: 'single',
    owner: '4f6qrVEi7fyiGuM74vy2WwLrGvVKDnT41WWSVWBjFEVS'
  },
  supply: { print_max_supply: 0, print_current_supply: 0, edition_nonce: null },
  mutable: true,
  burnt: false
}

```

#### V2 asset (note flags is wrong but that's true with the actual DAS indexing for this asset):
```
{
  interface: 'V1_NFT',
  id: 'CTs4CB81qEZCfkJeBNc4K4XyRKvAGQK5mQmmfdLenqVP',
  content: {
    '$schema': 'https://schema.metaplex.com/nft1.0.json',
    json_uri: 'https://example.com/my-nft.json',
    files: [],
    metadata: { name: 'My NFT', symbol: '', token_standard: 'NonFungible' },
    links: {}
  },
  authorities: [
    {
      address: '57Q5DBor4r19ZhM3Ffet4iLP5qMjjkRpj7GVL9YKRTMk',
      scopes: [Array]
    }
  ],
  compression: {
    eligible: false,
    compressed: true,
    data_hash: 'EHnEc36MD4gW2VvnJZ8LCDovJFRamyWSgfAh9EckHSdP',
    creator_hash: 'EKDHSGbrGztomDfuiV4iqiZ6LschDJPsFiXjZ83f92Md',
    collection_hash: '3mG2ogUZaUxX7TKRbDNDUPnesYghsd87YFAduqs4TETk',
    asset_data_hash: 'EKDHSGbrGztomDfuiV4iqiZ6LschDJPsFiXjZ83f92Md',
    flags: 0,
    asset_hash: 'B6JHK9tqzyqz5Ce8v49ob7EjFUb4ixAS3B8VGsZdsYWM',
    tree: '5srtRV8fetkPT5bH5QbrBwmAPTvoaxJ5au7grdfNJvw4',
    seq: 3,
    leaf_id: 0
  },
  grouping: [],
  royalty: {
    royalty_model: 'creators',
    target: null,
    percent: 0.05,
    basis_points: 500,
    primary_sale_happened: false,
    locked: false
  },
  creators: [],
  ownership: {
    frozen: true,
    non_transferable: false,
    delegated: true,
    delegate: '5AnsVodEgWktRJZ4b2vdfoErSQe4QnKsqx9pDavYpwUB',
    ownership_model: 'single',
    owner: '42W1H3oYFMc9UtwaAFT4Rs8ikjwf3VzLP8Sck4ScEsHL'
  },
  supply: { print_max_supply: 0, print_current_supply: 0, edition_nonce: null },
  mutable: true,
  burnt: false
}
```
